### PR TITLE
Issue#64

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,9 +30,12 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
+    elsif assigned_user == current_user || current_user == assign.team.owner
+      assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
+    elsif assigned_user != current_user || current_user != assign.team.owner
+      "削除権限はリーダーまたはメンバー本人のみ有します。"
     else
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
     end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,12 +30,11 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assigned_user == current_user || current_user == assign.team.owner
-      assign.destroy
+    elsif assigned_user != current_user && current_user != assign.team.owner
+      "削除権限はリーダーまたはメンバー本人のみ有します。"
+    elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
-    elsif assigned_user != current_user || current_user != assign.team.owner
-      "削除権限はリーダーまたはメンバー本人のみ有します。"
     else
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless current_user == @team.owner
+      redirect_to team_url, notice: "チーム情報はリーダーのみ編集可能です。"
+    end
+  end
 
   def create
     @team = Team.new(team_params)


### PR DESCRIPTION
- [ ] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

- [ ] TeamのeditはTeamのリーダー（オーナー）のみができるようにすること